### PR TITLE
Fixing regex detection

### DIFF
--- a/highlightRegex.js
+++ b/highlightRegex.js
@@ -49,7 +49,7 @@
 
   $.fn.highlightRegex = function( regex, options ) {
 
-    if ( typeof regex === 'object' && regex.constructor.name !== 'RegExp' ) {
+    if ( typeof regex === 'object' && !(regex.constructor.name == 'RegExp' || regex instanceof RegExp ) ) {
       options = regex
       regex = undefined
     }


### PR DESCRIPTION
In IE 11, `new RegExp('foo').constructor.name` is `undefined` so the plugin always confuses the regex with the options and never highlights anything.

This changes makes it also check `instanceof` which lets IE detect it correctly.
